### PR TITLE
EnergiBridge Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vagrant
+Session.vim
+Vagrantfile
 .idea
 .venv
 */__pycache__/*

--- a/examples/measure-self-profiling/README.md
+++ b/examples/measure-self-profiling/README.md
@@ -1,0 +1,35 @@
+# Self Measurement with `EnergiBridge`
+
+A simple Linux example, of how to enable the self-measurement feature of experiment-runner.
+
+We use the [EnergiBridge](https://github.com/tdurieux/EnergiBridge) program to measure power consuption
+of the entire system while performing any experiment.
+
+As an example program, we simply sleep for a number of seconds while
+
+## Requirements
+
+[EnergiBridge](https://github.com/tdurieux/EnergiBridge) is assumed to be already installed.
+To install EnergiBridge, please follow the instructions on their GitHub repo.
+
+By default we assume that (on Linux) your EnergiBridge binary executable is located at /usr/local/bin/energibridge.
+If you have installed it in a different location you can specify this in RunnerConfig.
+
+## Running
+
+Set RunnerConfig to True in your RunnerConfig.
+Optionally set self_measure_bin to the path of your executable.
+
+From the root directory of the repo, run the following command:
+
+```bash
+python experiment-runner/ examples/energibridge-profiling/RunnerConfig.py
+```
+
+## Results
+
+The results are generated in the `examples/energibridge-profiling/experiments` folder.
+
+**!!! WARNING !!!**: COLUMNS IN THE `energibridge.csv` FILES CAN BE DIFFERENT ACROSS MACHINES.
+ADJUST THE DATAFRAME COLUMN NAMES ACCORDINGLY.
+

--- a/examples/measure-self-profiling/RunnerConfig.py
+++ b/examples/measure-self-profiling/RunnerConfig.py
@@ -1,0 +1,131 @@
+from EventManager.Models.RunnerEvents import RunnerEvents
+from EventManager.EventSubscriptionController import EventSubscriptionController
+from ConfigValidator.Config.Models.RunTableModel import RunTableModel
+from ConfigValidator.Config.Models.FactorModel import FactorModel
+from ConfigValidator.Config.Models.RunnerContext import RunnerContext
+from ConfigValidator.Config.Models.OperationType import OperationType
+from ProgressManager.Output.OutputProcedure import OutputProcedure as output
+
+from typing import Dict, List, Any, Optional
+from pathlib import Path
+from os.path import dirname, realpath
+
+import os
+import signal
+import pandas as pd
+import time
+import subprocess
+import shlex
+
+class RunnerConfig:
+    ROOT_DIR = Path(dirname(realpath(__file__)))
+
+    # ================================ USER SPECIFIC CONFIG ================================
+    """The name of the experiment."""
+    name:                       str             = "new_runner_experiment"
+
+    """The path in which Experiment Runner will create a folder with the name `self.name`, in order to store the
+    results from this experiment. (Path does not need to exist - it will be created if necessary.)
+    Output path defaults to the config file's path, inside the folder 'experiments'"""
+    results_output_path:        Path             = ROOT_DIR / 'experiments'
+
+    """Experiment operation type. Unless you manually want to initiate each run, use `OperationType.AUTO`."""
+    operation_type:             OperationType   = OperationType.AUTO
+
+    """The time Experiment Runner will wait after a run completes.
+    This can be essential to accommodate for cooldown periods on some systems."""
+    time_between_runs_in_ms:    int             = 1000
+    
+    """
+    Whether EnergiBridge should be used to measure the energy consumption of the entire system durring
+    the experiment. 
+
+    This parameter is optional and defaults to False
+    """
+    self_measure:               bool            = True
+
+    """
+    Where the EnergiBridge executable is located. As its not a package on linux distros, and must be 
+    installed manually install location can vary.
+
+    This parameter is optional and defaults to /usr/local/bin/energibridge
+    """
+    felf_measure_bin:           Path            = "/usr/local/bin/energibridge"
+
+    # Dynamic configurations can be one-time satisfied here before the program takes the config as-is
+    # e.g. Setting some variable based on some criteria
+    def __init__(self):
+        """Executes immediately after program start, on config load"""
+
+        EventSubscriptionController.subscribe_to_multiple_events([
+            (RunnerEvents.BEFORE_EXPERIMENT, self.before_experiment),
+            (RunnerEvents.BEFORE_RUN       , self.before_run       ),
+            (RunnerEvents.START_RUN        , self.start_run        ),
+            (RunnerEvents.START_MEASUREMENT, self.start_measurement),
+            (RunnerEvents.INTERACT         , self.interact         ),
+            (RunnerEvents.STOP_MEASUREMENT , self.stop_measurement ),
+            (RunnerEvents.STOP_RUN         , self.stop_run         ),
+            (RunnerEvents.POPULATE_RUN_DATA, self.populate_run_data),
+            (RunnerEvents.AFTER_EXPERIMENT , self.after_experiment )
+        ])
+        self.run_table_model = None  # Initialized later
+        output.console_log("Custom config loaded")
+
+    def create_run_table_model(self) -> RunTableModel:
+        """Create and return the run_table model here. A run_table is a List (rows) of tuples (columns),
+        representing each run performed"""
+        self.run_table_model = RunTableModel(
+            factors = [],
+            data_columns=['example_data']
+        )
+        return self.run_table_model
+
+    def before_experiment(self) -> None:
+        """Perform any activity required before starting the experiment here
+        Invoked only once during the lifetime of the program."""
+        pass
+
+    def before_run(self) -> None:
+        """Perform any activity required before starting a run.
+        No context is available here as the run is not yet active (BEFORE RUN)"""
+        pass
+
+    def start_run(self, context: RunnerContext) -> None:
+        """Perform any activity required for starting the run here.
+        For example, starting the target system to measure.
+        Activities after starting the run should also be performed here."""
+        pass
+
+    def start_measurement(self, context: RunnerContext) -> None:
+        """Perform any activity required for starting measurements."""
+        pass
+
+    def interact(self, context: RunnerContext) -> None:
+        """Perform any interaction with the running target system here, or block here until the target finishes."""
+
+        # No interaction. We just run it for XX seconds while EnergiBridge measures.
+        output.console_log("Sleeping 5 seconds to measure system power consumption")
+        time.sleep(5)
+
+    def stop_measurement(self, context: RunnerContext) -> None:
+        """Perform any activity here required for stopping measurements."""
+        pass
+
+    def stop_run(self, context: RunnerContext) -> None:
+        """Perform any activity here required for stopping the run.
+        Activities after stopping the run should also be performed here."""
+        pass
+    
+    def populate_run_data(self, context: RunnerContext) -> Optional[Dict[str, Any]]:
+        """Parse and process any measurement data here.
+        You can also store the raw measurement data under `context.run_dir`
+        Returns a dictionary with keys `self.run_table_model.data_columns` and their values populated"""
+        return {"example_data": "test value"}
+
+    def after_experiment(self) -> None:
+        """Perform any activity required after stopping the experiment here
+        Invoked only once during the lifetime of the program."""
+        pass
+
+    # ================================ DO NOT ALTER BELOW THIS LINE ================================
+    experiment_path:            Path             = None

--- a/examples/measure-self-profiling/RunnerConfig.py
+++ b/examples/measure-self-profiling/RunnerConfig.py
@@ -1,21 +1,15 @@
 from EventManager.Models.RunnerEvents import RunnerEvents
 from EventManager.EventSubscriptionController import EventSubscriptionController
 from ConfigValidator.Config.Models.RunTableModel import RunTableModel
-from ConfigValidator.Config.Models.FactorModel import FactorModel
 from ConfigValidator.Config.Models.RunnerContext import RunnerContext
 from ConfigValidator.Config.Models.OperationType import OperationType
 from ProgressManager.Output.OutputProcedure import OutputProcedure as output
 
-from typing import Dict, List, Any, Optional
+from typing import Optional, Dict, Any
 from pathlib import Path
 from os.path import dirname, realpath
 
-import os
-import signal
-import pandas as pd
 import time
-import subprocess
-import shlex
 
 class RunnerConfig:
     ROOT_DIR = Path(dirname(realpath(__file__)))
@@ -50,7 +44,7 @@ class RunnerConfig:
 
     This parameter is optional and defaults to /usr/local/bin/energibridge
     """
-    felf_measure_bin:           Path            = "/usr/local/bin/energibridge"
+    self_measure_bin:           Path            = "/usr/local/bin/energibridge"
 
     # Dynamic configurations can be one-time satisfied here before the program takes the config as-is
     # e.g. Setting some variable based on some criteria

--- a/experiment-runner/ConfigValidator/Config/Validation/ConfigValidator.py
+++ b/experiment-runner/ConfigValidator/Config/Validation/ConfigValidator.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 from tabulate import tabulate
+import os
+import subprocess
+import platform
 
 from ExperimentOrchestrator.Misc.DictConversion import class_to_dict
 from ExperimentOrchestrator.Misc.PathValidation import is_path_exists_or_creatable_portable
@@ -18,7 +21,47 @@ class ConfigValidator:
                 .config_values_or_exception_dict[name] = str(ConfigValidator.config_values_or_exception_dict[name]) + \
                                                     f"\n\n{ConfigAttributeInvalidError(name, value, expected)}"
             ConfigValidator.error_found = True
+    
+    # Verifies that an energybridge executable is present, and can be executed without error
+    @staticmethod
+    def __validate_energibridge(measure_enabled, eb_path):
+        # Do nothing if its not enabled
+        if not measure_enabled:
+            return
 
+        if  not platform.system() == "Linux"    \
+            or not os.path.exists(eb_path)      \
+            or not os.access(eb_path, os.X_OK):
+
+            ConfigValidator.error_found = True
+            ConfigValidator \
+            .config_values_or_exception_dict["EnergiBridge"] = "EnergiBridge executable was not present or valid"
+
+        # Test run to see if energibridge works
+        try:
+            eb_args = [eb_path, "--summary", "-o", "/dev/null", "--", "sleep", "0.5"]
+            p = subprocess.Popen(eb_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+            stdout, stderr = p.communicate(timeout=5)
+
+            if stderr or not stdout:
+                ConfigValidator.error_found = True
+                ConfigValidator \
+                        .config_values_or_exception_dict["EnergiBridge"] = f"EnergiBridge error durring test:\n{stderr}"
+
+            
+            if "joules" not in stdout:
+                ConfigValidator.error_found = True
+                ConfigValidator \
+                        .config_values_or_exception_dict["EnergiBridge"] = f"Unexpected output durring EnergiBridge test:\n{stdout}"
+
+
+        except Exception as e:
+            ConfigValidator.error_found = True
+            ConfigValidator \
+                    .config_values_or_exception_dict["EnergiBridge"] = f"Exception durring EnergiBridge test:\n{e}"
+
+        
     @staticmethod
     def validate_config(config: RunnerConfig):
 
@@ -27,6 +70,13 @@ class ConfigValidator:
         if '~' in str(config.experiment_path):
             config.experiment_path = config.experiment_path.expanduser()
         
+        # Set defaults to support configs without the self_measure parameter
+        if not hasattr(config, "self_measure"):
+            config.self_measure = False
+
+        if config.self_measure and not hasattr(config, "self_measure_bin"):
+            config.self_measure_bin = "/usr/local/bin" # This is spesific to linux, might work for osx as well
+
         # Convert class to dictionary with utility method
         ConfigValidator.config_values_or_exception_dict = class_to_dict(config)
 
@@ -51,6 +101,8 @@ class ConfigValidator:
                             "path must be valid and writable",
                             (lambda a, b: is_path_exists_or_creatable_portable(a))
                         )
+        
+        ConfigValidator.__validate_energibridge(config.self_measure, config.self_measure_bin)
 
         # Display config in user-friendly manner, including potential errors found
         print(

--- a/experiment-runner/ConfigValidator/Config/Validation/ConfigValidator.py
+++ b/experiment-runner/ConfigValidator/Config/Validation/ConfigValidator.py
@@ -75,7 +75,7 @@ class ConfigValidator:
             config.self_measure = False
 
         if config.self_measure and not hasattr(config, "self_measure_bin"):
-            config.self_measure_bin = "/usr/local/bin" # This is spesific to linux, might work for osx as well
+            config.self_measure_bin = "/usr/local/bin/energibridge" # This is spesific to linux, might work for osx as well
 
         # Convert class to dictionary with utility method
         ConfigValidator.config_values_or_exception_dict = class_to_dict(config)

--- a/experiment-runner/ExperimentOrchestrator/Experiment/ExperimentController.py
+++ b/experiment-runner/ExperimentOrchestrator/Experiment/ExperimentController.py
@@ -36,8 +36,17 @@ class ExperimentController:
 
         self.csv_data_manager = CSVOutputManager(self.config.experiment_path)
         self.json_data_manager = JSONOutputManager(self.config.experiment_path)
-        self.run_table = self.config.create_run_table_model().generate_experiment_run_table()
+        run_tbl = self.config.create_run_table_model()
+        
+        # Add in the proper data column for energibridge
+        if self.config.self_measure:
+            if "self-measure" in run_tbl._RunTableModel__data_columns:
+                raise BaseError("Cannot use self-measure as data column name if self_measure is active")
 
+            run_tbl._RunTableModel__data_columns.append("self-measure")
+
+        self.run_table = run_tbl.generate_experiment_run_table()
+        
         # Create experiment output folder, and in case that it exists, check if we can resume
         self.restarted = False
         try:

--- a/experiment-runner/ExperimentOrchestrator/Experiment/Run/RunController.py
+++ b/experiment-runner/ExperimentOrchestrator/Experiment/Run/RunController.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from ProgressManager.RunTable.Models.RunProgress import RunProgress
 from EventManager.Models.RunnerEvents import RunnerEvents
 from EventManager.EventSubscriptionController import EventSubscriptionController
@@ -6,8 +8,45 @@ from ExperimentOrchestrator.Experiment.Run.IRunController import IRunController
 from ProgressManager.Output.OutputProcedure import OutputProcedure as output
 
 class RunController(IRunController):
+    # Start EnergiBridge measurements
+    def start_eb(self):
+        if not self.config.self_measure:
+            return
+
+        eb_args = [self.config.self_measure_bin, "--summary",
+                   "-o", "/dev/null", "--", "sleep", "1000000"]
+
+        try:
+            self.eb_proc = subprocess.Popen(eb_args, stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE, text=True)
+        except Exception as e:
+            output.console_log_FAIL(f"Error while starting EnergiBridge:\n{e}")
+
+    # Stop EnergiBridge  
+    def stop_eb(self):
+        if not self.config.self_measure or not self.eb_proc:
+            return
+
+        try:
+            self.eb_proc.terminate()
+            stdout, stderr = self.eb_proc.communicate()
+            
+            if stderr:
+                output.console_log_FAIL(f"EnergiBridge error encountered:\n{stderr}")
+
+            if "joules:" not in stdout:
+                output.console_log_FAIL("EnergiBridge error: Could not extract joules from output")
+            
+            self.run_context.run_variation["self-measure"] = round(float(stdout.split(" ")[6]), 3)
+
+        except Exception as e:
+            output.console_log_FAIL(f"Failed to stop EnergiBridge:\n{e}")
+
     @processify
     def do_run(self):
+        # Start EnergiBridge
+        self.start_eb()
+
         # -- Start run
         output.console_log_WARNING("Calling start_run config hook")
         EventSubscriptionController.raise_event(RunnerEvents.START_RUN, self.run_context)
@@ -32,6 +71,9 @@ class RunController(IRunController):
         # -- Collect data from measurements
         output.console_log_WARNING("Calling populate_run_data config hook")
         user_run_data = EventSubscriptionController.raise_event(RunnerEvents.POPULATE_RUN_DATA, self.run_context)
+        
+        # Stop EnergiBridge
+        self.stop_eb()
 
         if user_run_data:
             # TODO: check if data columns exist and if yes, if they match


### PR DESCRIPTION
This PR implements a self-measurement feature for RunnerConfig, such that a user can simply specify self-measure=True, and receive energy measurements in their results.

- Currently only supports Linux (could also support other oses if needed)
- Requires EnergiBridge to already be installed

+ Also implements customizable install location for EnergiBridge, as its user installed it might be in different locations
+ Added config validation for self-measure
+ Added an example of how to enable self-measurement.