### PR TITLE
Replace ast.Str with ast.Constant (ast.Str removed in Python 3.14)

### DIFF
--- a/experiment-runner/__main__.py
+++ b/experiment-runner/__main__.py
@@ -41,7 +41,7 @@ def calc_ast_md5sum(src, name):
         # Ignore docstring
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef, ast.Module)) and ast.get_docstring(node) is not None:
             docstring_node = node.body[0].value
-            if isinstance(docstring_node, ast.Str):
+            if isinstance(docstring_node, ast.Constant):
                 docstring_node.s = ''
             elif isinstance(docstring_node, ast.Constant) and isinstance(docstring_node.value, str):
                 docstring_node.value = ''


### PR DESCRIPTION
## What
Replaces usage of `ast.Str` with `ast.Constant` in `__main__.py`.

## Why
`ast.Str`, along with `ast.Num`, `ast.Bytes`, `ast.NameConstant`, and `ast.Ellipsis`,
was deprecated in Python 3.8 and has now been removed in Python 3.14.  Any code still
referencing `ast.Str` will fail with an `ImportError`/`AttributeError` on 3.14+.

## Compatibility
`ast.Constant` has been available since Python 3.8, so this change is fully
backward-compatible with all currently supported Python versions (3.8+) and
adds support for 3.14+.